### PR TITLE
Fix stats overdue date comparison

### DIFF
--- a/src/ofocus/cli.py
+++ b/src/ofocus/cli.py
@@ -34,7 +34,9 @@ cli.add_command(tag)
 @click.option("--json", "as_json", is_flag=True, help="Output JSON")
 def stats(as_json):
     """Show quick counts."""
-    script = """\
+    script = (
+        jxa.JS_LOCAL_DATE_HELPERS
+        + """\
 var app = Application("OmniFocus");
 var doc = app.defaultDocument;
 var inbox = doc.inboxTasks().length;
@@ -46,10 +48,11 @@ var tags = doc.flattenedTags().length;
 var flagged = doc.flattenedTasks().filter(function(t) {
     return t.flagged() && !t.completed() && !t.dropped();
 }).length;
+var today = toLocalDateString(new Date());
 var overdue = doc.flattenedTasks().filter(function(t) {
     if (t.completed() || t.dropped()) return false;
     var d = t.dueDate();
-    return d && d < new Date();
+    return d && toLocalDateString(d) < today;
 }).length;
 JSON.stringify({
     inbox: inbox,
@@ -60,6 +63,7 @@ JSON.stringify({
     overdue: overdue
 });
 """
+    )
     try:
         result = jxa.run_jxa(script)
     except OmniError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,6 +180,32 @@ def test_stats_excludes_dropped_from_active_and_overdue(monkeypatch):
     assert "t.completed() || t.dropped()" in scripts[0]
 
 
+def test_stats_overdue_uses_local_calendar_dates(monkeypatch):
+    scripts = []
+
+    def fake_run_jxa(script):
+        scripts.append(script)
+        return {
+            "inbox": 0,
+            "active": 0,
+            "projects": 0,
+            "tags": 0,
+            "flagged": 0,
+            "overdue": 0,
+        }
+
+    monkeypatch.setattr(_PATCH_JXA, fake_run_jxa)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stats", "--json"])
+
+    assert result.exit_code == 0
+    assert len(scripts) == 1
+    assert "toLocalDateString" in scripts[0]
+    assert "var today = toLocalDateString(new Date());" in scripts[0]
+    assert "toLocalDateString(d) < today" in scripts[0]
+    assert "d && d < new Date()" not in scripts[0]
+
+
 def test_run_jxa_timeout_raises_omnierror(monkeypatch):
     def fake_run(*args, **kwargs):
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 0))


### PR DESCRIPTION
## Summary
Fix `ofocus stats` so tasks due today are not counted as overdue just because the current clock time is later than midnight.

## Evidence
- Commit: `df51fe288feae94d84a5e015acc75273b6dcaf8a`
- Files: `src/ofocus/cli.py`, `tests/test_cli.py`
- Diff: 32 insertions, 2 deletions
- Regression test added for the generated JXA overdue comparison

## Verification
- `uv run pytest tests/test_cli.py -q`
- `uv run pytest`
- `uv run ruff check src tests`

## CI Signals
- GitHub checks pending or unavailable at PR creation time; see PR checks for current state.
